### PR TITLE
a new opentelemetry_mask directive

### DIFF
--- a/src/ngx_http_opentelemetry_module.h
+++ b/src/ngx_http_opentelemetry_module.h
@@ -15,5 +15,8 @@ int ngx_http_opentelemetry_span_debug(ngx_http_request_t *r, opentelemetry_span 
 int ngx_http_opentelemetry_span_headers_get(ngx_http_request_t *r, opentelemetry_span *span, opentelemetry_header_each header_each, void *header_each_arg);
 opentelemetry_span *ngx_http_opentelemetry_span_start_headers(ngx_http_request_t *r, const char *operation_name, size_t operation_name_len, opentelemetry_header_value header_value, void *header_value_arg);
 void ngx_http_opentelemetry_span_finish(ngx_http_request_t *r, opentelemetry_span *span);
+ngx_array_t *ngx_http_opentelemetry_get_mask_rule(ngx_http_request_t *r, const opentelemetry_string *rule_name);
+ngx_array_t *ngx_http_opentelemetry_get_rule_list(ngx_array_t *mask_rule, const opentelemetry_string *name);
+ngx_int_t ngx_http_apply_header_mask_list(ngx_http_request_t *r, ngx_array_t *mask_list, ngx_str_t *header_value);
 
 #endif


### PR DESCRIPTION
The directive is used to replace values in span_event(). The third parameter in span_event call is used to describe a mask name to be replaced

Syntax: opentelemetry_mask mask_name attr_name regex mask;

Example opentelemetry_mask headers_event Authorization ^.*$ SECRET;

lua code example:
span_event("Headers", {Authorization="masked_value"}, "headers_event")